### PR TITLE
Add create organization feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,16 +1,17 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  Excludes:
+  Exclude:
     - db/schema.rb
     - db/migrate/**
     - vendor/bundle/**/*
     - node_modules/**/*
 
-Style/BlockLength:
+Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - Guardfile
+    - config/environments/production.rb
 
 Style/Documentation:
   Exclude:

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,24 @@
+class OrganizationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @organization = Organization.new
+  end
+
+  def create
+    @organization = Organization.new(organization_params)
+    @organization.owner = current_user
+    if @organization.save
+      flash[:success] = 'Your organization has been successfully created'
+      redirect_to root_path
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def organization_params
+    params.require(:organization).permit(:name)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def render_errors_for(obj)
+    return unless obj.errors.any?
+    render 'layouts/errors', obj: obj
+  end
 end

--- a/app/javascript/stylesheets/alerts.scss
+++ b/app/javascript/stylesheets/alerts.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
 
   span {
-    align-self: center
+    align-self: center;
   }
 
   .dismiss {
@@ -16,9 +16,13 @@
 }
 
 .alert-alert {
-  background-color: #da1717
+  background-color: #da1717;
 }
 
 .alert-notice {
-  background-color: #3691ca
+  background-color: #3691ca;
+}
+
+.alert-success {
+  background-color: #5a9e21;
 }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,4 +3,5 @@ class Organization < ApplicationRecord
 
   has_many :inventories
   has_and_belongs_to_many :users
+  belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_and_belongs_to_many :organizations
   has_many :inventory_users
   has_many :inventories, through: :inventory_users
+  has_many :owned_organizations, class_name: 'Organization', foreign_key: 'owner_id'
 end

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,0 +1,6 @@
+<%= render_errors_for(@organization) %>
+
+<%= form_for @organization do |f| %>
+  <%= f.text_field :name %>
+  <%= f.submit 'Create Organization' %>
+<% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,4 @@
 <h1>Tenacious</h1>
 <p>A tenacious inventory system</p>
+
+<%= link_to 'Create an Organization', new_organization_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'pages#home'
   devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :organizations, only: [:new, :create]
 end

--- a/db/migrate/20170713185103_add_owner_id_to_organization.rb
+++ b/db/migrate/20170713185103_add_owner_id_to_organization.rb
@@ -1,0 +1,5 @@
+class AddOwnerIdToOrganization < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :owner_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710193759) do
+ActiveRecord::Schema.define(version: 20170713185103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170710193759) do
     t.string "name", limit: 255, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "owner_id", null: false
   end
 
   create_table "organizations_users", id: false, force: :cascade do |t|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :organization do
     name { Faker::Name.unique.first_name }
+    association :owner, factory: :user
   end
 end

--- a/spec/features/organizations/create_organization_spec.rb
+++ b/spec/features/organizations/create_organization_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.feature 'Creating an organization' do
+  let(:user) { FactoryGirl.create(:user, :confirmed) }
+  let(:organization) { FactoryGirl.build(:organization, owner: user) }
+
+  before do
+    visit '/'
+  end
+
+  feature 'as an authenticated user' do
+    let!(:original_organization_count) { Organization.count }
+
+    before do
+      login_as(user)
+      click_link 'Create an Organization'
+    end
+
+    feature 'with valid inputs' do
+      before do
+        fill_in 'organization_name', with: organization.name
+        click_button 'Create Organization'
+      end
+
+      scenario 'succeeds' do
+        created_organization = Organization.last
+        expect(Organization.count - original_organization_count).to be(1)
+        expect(created_organization.owner).to eq(organization.owner)
+        expect(created_organization.name).to eq(organization.name)
+        expect(current_path).to eq(root_path)
+      end
+
+      scenario 'shows a message saying the organization was created' do
+        expect(page).to have_content('Your organization has been successfully created')
+      end
+    end
+
+    feature 'with no inputs' do
+      before do
+        click_button 'Create Organization'
+      end
+
+      scenario 'fails' do
+        expect(Organization.count).to eq(original_organization_count)
+      end
+
+      scenario 'shows messages saying why the organization was not created' do
+        expect(page).to have_content("Name can't be blank")
+      end
+    end
+  end
+
+  scenario 'as a guest redirects to the log in page' do
+    click_link 'Create an Organization'
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
+    expect(current_path).to eq(new_user_session_path)
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -33,15 +33,22 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe '#user association' do
-    it 'is valid when it has a user' do
-      user = FactoryGirl.create(:user)
-      expect(FactoryGirl.build(:organization, users: [user])).to be_valid
+  describe '#owner' do
+    it 'is invalid when nil' do
+      expect(FactoryGirl.build(:organization, owner: nil)).not_to be_valid
     end
 
-    it 'is valid when it has users' do
-      users = FactoryGirl.create_list(:user, 2)
-      expect(FactoryGirl.build(:organization, users: users)).to be_valid
+    it 'is a user' do
+      organization = FactoryGirl.create(:organization)
+      expect(organization.owner).to be_a(User)
+    end
+  end
+
+  describe '#users' do
+    it 'returns users belonging to the organization' do
+      organization = FactoryGirl.create(:organization)
+      users = FactoryGirl.create_list(:user, 2, organizations: [organization])
+      expect(organization.users).to eq(users)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,18 +15,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#organization association' do
-    it 'is valid when it has an organization' do
-      org = FactoryGirl.create(:organization)
-      expect(FactoryGirl.build(:user, organizations: [org])).to be_valid
-    end
-
-    it 'is valid when it has organizations' do
-      orgs = FactoryGirl.create_list(:organization, 2)
-      expect(FactoryGirl.build(:user, organizations: orgs)).to be_valid
-    end
-  end
-
   describe '#inventory association' do
     let(:user) { FactoryGirl.create(:user) }
 
@@ -41,6 +29,22 @@ RSpec.describe User, type: :model do
         FactoryGirl.create(:inventory_user, :read, inventory: inventory, user: user)
       end
       expect(user.inventories).to eq inventories
+    end
+  end
+
+  describe '#organizations' do
+    it 'returns organizations it belongs to' do
+      user = FactoryGirl.create(:user)
+      orgs = FactoryGirl.create_list(:organization, 2, users: [user])
+      expect(user.organizations).to eq(orgs)
+    end
+  end
+
+  describe '#owned_organizations' do
+    it 'returns organizations it owns' do
+      user = FactoryGirl.create(:user)
+      orgs = FactoryGirl.create_list(:organization, 2, owner: user)
+      expect(user.owned_organizations).to eq(orgs)
     end
   end
 end


### PR DESCRIPTION
Resolves #19 

My spec focused on separating the creation of the organization with the ui messages showing an organization was created or if there were errors.

I didn't test for every way the form could fail as I feel that would be a repeat of all the validations in the model spec

I also asserted things like expect(current_path).to eq root_path in the spec which will have to change when we redirect to a more meaningful route.

Added a success alert with a green background

The link for adding an organization will eventually be moved to a profile or dashboard page wherever we decide in the future

I left the form unstyled for now as I am not very familiar with styling forms but we can create an issue for users wanting visually appealing forms in the future

Rendered out errors_for into application helper

Duplicated the rubocop configuration from #82 so it shouldn't have a merge conflict for whichever of these are pulled in first

I didn't create a form partial as we haven't decided on a user story for editing an organization yet.