### PR TITLE
Create Inventory new, create, and show actions with polymorphic associations

### DIFF
--- a/app/controllers/inventories_controller.rb
+++ b/app/controllers/inventories_controller.rb
@@ -1,0 +1,46 @@
+class InventoriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_owner
+  before_action :validate_organization_owner, only: [:new, :create]
+
+  def new
+    @inventory = Inventory.new
+  end
+
+  def create
+    @inventory = Inventory.new(inventory_params)
+    @inventory.owner = @owner
+    if @inventory.save
+      inventory_user = InventoryUser.new(user: current_user, inventory: @inventory, user_role: 'admin')
+      inventory_user.save
+      flash[:success] = 'Your inventory has been successfully created'
+      redirect_to [@owner, @inventory]
+    else
+      render 'new'
+    end
+  end
+
+  def show
+    @inventory = Inventory.find(params[:id])
+    return if @inventory.users.include? current_user
+    flash[:alert] = 'You need to be part of this inventory to view it'
+    redirect_to root_path
+  end
+
+  private
+
+  def inventory_params
+    params.require(:inventory).permit(:name, :description)
+  end
+
+  def set_owner
+    resource, id = request.path.split('/')[1, 2]
+    @owner = resource.singularize.classify.constantize.find(id)
+  end
+
+  def validate_organization_owner
+    return unless @owner.class == Organization && @owner.owner != current_user
+    flash[:alert] = 'Only the owner of an organization can create an inventory for it'
+    redirect_to organization_path(@owner)
+  end
+end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -19,6 +19,7 @@ class OrganizationsController < ApplicationController
 
   def show
     @organization = Organization.find(params[:id])
+    @inventories = @organization.owned_inventories
     return if @organization.users.include? current_user
     flash[:alert] = 'You need to be part of this organization to view it'
     redirect_to root_path

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,5 +6,6 @@ class PagesController < ApplicationController
 
   def dashboard
     @organizations = current_user.organizations
+    @inventories = current_user.inventories
   end
 end

--- a/app/javascript/application.scss
+++ b/app/javascript/application.scss
@@ -1,4 +1,4 @@
-@import 'stylesheets/reset.scss';
+@import 'stylesheets/custom.scss';
 @import 'stylesheets/navbar.scss';
 @import 'stylesheets/alerts.scss';
 @import 'stylesheets/forms.scss';

--- a/app/javascript/application.scss
+++ b/app/javascript/application.scss
@@ -1,3 +1,4 @@
 @import 'stylesheets/reset.scss';
 @import 'stylesheets/navbar.scss';
 @import 'stylesheets/alerts.scss';
+@import 'stylesheets/forms.scss';

--- a/app/javascript/stylesheets/alerts.scss
+++ b/app/javascript/stylesheets/alerts.scss
@@ -1,3 +1,5 @@
+@import 'stylesheets/variables.scss';
+
 .alert {
   padding: 10px;
   color: white;
@@ -16,7 +18,7 @@
 }
 
 .alert-alert {
-  background-color: #da1717;
+  background-color: $error-color;
 }
 
 .alert-notice {

--- a/app/javascript/stylesheets/custom.scss
+++ b/app/javascript/stylesheets/custom.scss
@@ -1,0 +1,16 @@
+body {
+  margin: 0;
+}
+
+body > main {
+  padding: 0 20px;
+}
+
+.card {
+  padding: 10px 40px;
+  border-radius: 4px;
+  border: 1px solid #e8e8e8;
+  box-shadow: 0 1px 0 rgba(0,0,0,.25);
+  margin-bottom: 20px;
+  max-width: 400px;
+}

--- a/app/javascript/stylesheets/forms.scss
+++ b/app/javascript/stylesheets/forms.scss
@@ -1,0 +1,27 @@
+@import 'stylesheets/variables.scss';
+
+.field {
+  width: 100%;
+  max-width: 400px;
+  margin: 20px 0;
+
+  input, textarea {
+    width: 100%;
+    padding: 5px 0;
+    border: none;
+    outline: none;
+    border-bottom: 1px solid black;
+  }
+
+  input[type='checkbox'] {
+    width: auto;
+  }
+}
+
+.field_with_errors {
+  color: $error-color;
+
+  input {
+    border-bottom: 1px solid $error-color;
+  }
+}

--- a/app/javascript/stylesheets/navbar.scss
+++ b/app/javascript/stylesheets/navbar.scss
@@ -28,6 +28,7 @@ nav {
   form input {
     background: none;
     border: none;
+    outline: none;
     font: inherit;
     cursor: pointer;
   }

--- a/app/javascript/stylesheets/reset.scss
+++ b/app/javascript/stylesheets/reset.scss
@@ -1,7 +1,0 @@
-body {
-  margin: 0;
-}
-
-body > main {
-  padding: 0 20px;
-}

--- a/app/javascript/stylesheets/variables.scss
+++ b/app/javascript/stylesheets/variables.scss
@@ -1,0 +1,1 @@
+$error-color: #da1717;

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -4,4 +4,5 @@ class Inventory < ApplicationRecord
 
   has_many :inventory_users
   has_many :users, through: :inventory_users
+  belongs_to :owner, polymorphic: true
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,6 +2,7 @@ class Organization < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false}, length: { maximum: 255 }
 
   has_many :inventories
+  has_many :owned_inventories, class_name: 'Inventory', as: :owner
   has_and_belongs_to_many :users
-  belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
+  belongs_to :owner, class_name: 'User'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,6 @@ class User < ApplicationRecord
   has_and_belongs_to_many :organizations
   has_many :inventory_users
   has_many :inventories, through: :inventory_users
+  has_many :owned_inventories, class_name: 'Inventory', as: :owner
   has_many :owned_organizations, class_name: 'Organization', foreign_key: 'owner_id'
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,31 +1,24 @@
 <h2>Sign up</h2>
 
-<% if resource.errors.any? %>
-  <%= render 'layouts/errors', obj: resource %>
-<% end %>
+<%= render_errors_for(resource) %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
+  <div class='field'>
+    <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>
   </div>
 
-  <div class="field">
+  <div class='field'>
     <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
+    <%= f.password_field :password, autocomplete: 'off' %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  <div class='field'>
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: 'off' %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
+  <%= f.submit 'Sign up' %>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,24 @@
-<h2>Log in</h2>
+<h2>Sign in</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
+  <div class='field'>
+    <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>
   </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
+  <div class='field'>
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: 'off' %>
   </div>
 
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
+  <% if devise_mapping.rememberable? %>
+    <div class='field'>
       <%= f.check_box :remember_me %>
       <%= f.label :remember_me %>
     </div>
-  <% end -%>
+  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
+  <%= f.submit 'Sign in' %>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%= render 'devise/shared/links' %>

--- a/app/views/inventories/new.html.erb
+++ b/app/views/inventories/new.html.erb
@@ -1,13 +1,21 @@
+<% if @owner.class == Organization %>
+  <h2>Create an Inventory for <%= link_to @owner.name, organization_path(@owner) %></h2>
+<% else %>
+  <h2>Create an Inventory for yourself</h2>
+<% end %>
+
 <%= render_errors_for(@inventory) %>
 
 <%= form_for [@owner, @inventory] do |f| %>
-  <div>
+  <div class='field'>
     <%= f.label :name %>
-    <%= f.text_field :name %>
+    <%= f.text_field :name, autofocus: true %>
   </div>
-  <div>
+
+  <div class='field'>
     <%= f.label :description %>
-    <%= f.text_area :description %>
+    <%= f.text_area :description, rows: 4 %>
   </div>
+
   <%= f.submit 'Create Inventory' %>
 <% end %>

--- a/app/views/inventories/new.html.erb
+++ b/app/views/inventories/new.html.erb
@@ -1,0 +1,13 @@
+<%= render_errors_for(@inventory) %>
+
+<%= form_for [@owner, @inventory] do |f| %>
+  <div>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+  <div>
+    <%= f.label :description %>
+    <%= f.text_area :description %>
+  </div>
+  <%= f.submit 'Create Inventory' %>
+<% end %>

--- a/app/views/inventories/show.html.erb
+++ b/app/views/inventories/show.html.erb
@@ -1,0 +1,6 @@
+<h1><%= @inventory.name %></h1>
+<p><%= @inventory.description %></p>
+
+<% if @inventory.owner_type == 'Organization' %>
+  <%= link_to @inventory.owner.name, organization_path(@inventory.owner) %>
+<% end %>

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -5,6 +5,7 @@
   </span> 
   <span class='dismiss'>&times;</span>
 </div>
+
 <% obj.errors.full_messages.each do |msg| %>
   <div class='alert alert-alert'>
     <span><%= msg %></span> <span class='dismiss'>&times;</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>Tenacious</title>
     <%= csrf_meta_tags %>
     <%= stylesheet_pack_tag 'application' %>
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <meta name='viewport' content='width=device-width, initial-scale=1, minimum-scale=1'>
   </head>
 
   <body>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,6 +1,12 @@
+<h2>Create an Organization</h2>
+
 <%= render_errors_for(@organization) %>
 
 <%= form_for @organization do |f| %>
-  <%= f.text_field :name %>
+  <div class='field'>
+    <%= f.label :name %>
+    <%= f.text_field :name, autofocus: true %>
+  </div>
+
   <%= f.submit 'Create Organization' %>
 <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,1 +1,5 @@
 <h1><%= @organization.name %></h1>
+
+<% if @organization.owner == current_user %>
+  <%= link_to 'Create an Inventory', new_organization_inventory_path(@organization) %>
+<% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,5 +1,19 @@
 <h1><%= @organization.name %></h1>
 
-<% if @organization.owner == current_user %>
-  <%= link_to 'Create an Inventory', new_organization_inventory_path(@organization) %>
-<% end %>
+<div class='card'>
+  <h4>Inventories</h4>
+
+  <% unless @inventories.empty? %>
+    <ul>
+      <% @inventories.each do |inventory| %>
+        <li>
+          <%= link_to inventory.name, organization_inventory_path(inventory.owner, inventory) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @organization.owner == current_user %>
+    <%= link_to 'Create an Inventory', new_organization_inventory_path(@organization) %>
+  <% end %>
+</div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -5,3 +5,4 @@
 <% end %>
 
 <%= link_to 'Create an Organization', new_organization_path %>
+<%= link_to 'Create an Inventory', new_user_inventory_path(current_user) %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,8 +1,33 @@
-<% @organizations.each do |organization| %>
-  <ul>
-    <li><%= link_to organization.name, organization_path(organization) %></li>
-  </ul>
-<% end %>
+<div class='card'>
+  <h4>Organizations</h4>
 
-<%= link_to 'Create an Organization', new_organization_path %>
-<%= link_to 'Create an Inventory', new_user_inventory_path(current_user) %>
+  <% unless @organizations.empty? %>  
+    <ul>
+      <% @organizations.each do |organization| %>
+        <li><%= link_to organization.name, organization_path(organization) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= link_to 'Create an Organization', new_organization_path %>
+</div>
+
+<div class='card'>
+  <h4>Inventories</h4>
+
+  <% unless @inventories.empty? %>
+    <ul>
+      <% @inventories.each do |inventory| %>
+        <li>
+          <% if inventory.owner_type == 'Organization' %>
+            <%= link_to "#{inventory.owner.name} / #{inventory.name}", organization_inventory_path(inventory.owner, inventory) %>
+          <% else %>
+            <%= link_to inventory.name, user_inventory_path(current_user, inventory) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= link_to 'Create an Inventory', new_user_inventory_path(current_user) %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,10 @@ Rails.application.routes.draw do
   root 'pages#home'
   get '/dashboard', to: 'pages#dashboard'
   devise_for :users
-  resources :organizations, only: [:new, :create, :show]
+  resources :users, only: [] do
+    resources :inventories, only: [:new, :create, :show]
+  end
+  resources :organizations, only: [:new, :create, :show] do
+    resources :inventories, only: [:new, :create, :show]
+  end
 end

--- a/db/migrate/20170726083607_add_polymorphic_owner_id_to_inventories.rb
+++ b/db/migrate/20170726083607_add_polymorphic_owner_id_to_inventories.rb
@@ -1,0 +1,7 @@
+class AddPolymorphicOwnerIdToInventories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :inventories, :owner_id, :integer, null: false
+    add_column :inventories, :owner_type, :string, null: false
+    add_index :inventories, [:owner_id, :owner_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713185103) do
+ActiveRecord::Schema.define(version: 20170726083607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 20170713185103) do
     t.string "description", limit: 255
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "owner_id", null: false
+    t.string "owner_type", null: false
+    t.index ["owner_id", "owner_type"], name: "index_inventories_on_owner_id_and_owner_type"
   end
 
   create_table "inventory_users", force: :cascade do |t|

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :inventory do
     name { Faker::Name.unique.first_name }
     description { Faker::Lorem.sentence }
+    association :owner, factory: [:user, :organization].sample
   end
 end

--- a/spec/features/inventories/create_inventory_spec.rb
+++ b/spec/features/inventories/create_inventory_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+require 'features/feature_helpers'
+include FeatureHelpers
+
+RSpec.feature 'Creating an inventory' do
+  let(:org_owner) { FactoryGirl.create(:user, :confirmed) }
+  let(:member) { FactoryGirl.create(:user, :confirmed) }
+  let(:inventory) { FactoryGirl.build(:inventory) }
+  let!(:organization) { FactoryGirl.create(:organization, owner: org_owner, users: [org_owner, member]) }
+  let!(:original_inventory_count) { Inventory.count }
+
+  shared_examples 'a failed inventory creation' do
+    feature 'with no inputs' do
+      before do
+        click_button 'Create Inventory'
+      end
+
+      feature 'fails' do
+        scenario "and doesn't save the inventory to the database" do
+          expect(Inventory.count).to eq(original_inventory_count)
+        end
+
+        scenario 'and shows a messages saying why the inventory was not created' do
+          expect(page).to have_content("Name can't be blank")
+        end
+      end
+    end
+  end
+
+  shared_examples 'a successful inventory creation' do |owner_string|
+    feature 'with valid inputs' do
+      if owner_string == 'organization'
+        let(:owner) { organization }
+      elsif owner_string == 'org_owner'
+        let(:owner) { org_owner }
+      end
+
+      before do
+        fill_in 'inventory_name', with: inventory.name
+        fill_in 'inventory_description', with: inventory.description
+        click_button 'Create Inventory'
+      end
+
+      feature 'succeeds' do
+        let(:created_inventory) { Inventory.last }
+
+        scenario 'and saves the inventory to the database' do
+          expect(Inventory.count - original_inventory_count).to eq(1)
+        end
+
+        scenario 'and has the same attributes as input into the form' do
+          expect(created_inventory.name).to eq(inventory.name)
+          expect(created_inventory.description).to eq(inventory.description)
+        end
+
+        scenario 'and sets the owner as the owner of the inventory' do
+          expect(created_inventory.owner).to eq(owner)
+        end
+
+        scenario 'and includes the user as part of he inventory' do
+          expect(created_inventory.users).to include(org_owner)
+        end
+
+        scenario 'and sets the user_role on the inventory as admin' do
+          expect(InventoryUser.where(user_id: org_owner, inventory_id: created_inventory)[0].user_role).to eq('admin')
+        end
+
+        scenario 'and redirects to the inventory path' do
+          if owner_string == 'organization'
+            expect(current_path).to eq(organization_inventory_path(owner, created_inventory))
+          elsif owner_string == 'org_owner'
+            expect(current_path).to eq(user_inventory_path(owner, created_inventory))
+          end
+        end
+
+        scenario 'and shows a message saying the inventory was created' do
+          expect(page).to have_content('Your inventory has been successfully created')
+        end
+      end
+    end
+  end
+
+  feature 'as a user through the user route' do
+    before do
+      login_as(org_owner)
+      visit '/'
+      click_link 'Dashboard'
+      click_link 'Create an Inventory'
+    end
+
+    include_examples 'a successful inventory creation', 'org_owner'
+
+    include_examples 'a failed inventory creation'
+  end
+
+  feature 'as the owner of the organization through the organization route' do
+    before do
+      login_as(org_owner)
+      visit '/'
+      click_link 'Dashboard'
+      click_link organization.name
+      click_link 'Create an Inventory'
+    end
+
+    include_examples 'a successful inventory creation', 'organization'
+
+    include_examples 'a failed inventory creation'
+  end
+
+  feature 'as a member of the organization' do
+    before do
+      login_as(member)
+      visit new_organization_inventory_path(organization)
+    end
+
+    scenario 'will redirect back to the organization path' do
+      expect(current_path).to eq(organization_path(organization))
+    end
+
+    scenario 'shows a message saying why the member was redirected' do
+      expect(page).to have_content('Only the owner of an organization can create an inventory for it')
+    end
+  end
+
+  feature 'as a guest' do
+    before do
+      visit new_user_inventory_path(org_owner)
+    end
+
+    will_redirect_to_login_page
+  end
+end

--- a/spec/features/inventories/create_inventory_spec.rb
+++ b/spec/features/inventories/create_inventory_spec.rb
@@ -88,6 +88,10 @@ RSpec.feature 'Creating an inventory' do
       click_link 'Create an Inventory'
     end
 
+    scenario 'shows that the inventory will be created under the user' do
+      expect(page).to have_content('Create an Inventory for yourself')
+    end
+
     include_examples 'a successful inventory creation', 'org_owner'
 
     include_examples 'a failed inventory creation'
@@ -100,6 +104,14 @@ RSpec.feature 'Creating an inventory' do
       click_link 'Dashboard'
       click_link organization.name
       click_link 'Create an Inventory'
+    end
+
+    scenario 'shows that the inventory will be created under the organization' do
+      expect(page).to have_content("Create an Inventory for #{organization.name}")
+    end
+
+    scenario 'has a link to the organization' do
+      expect(page).to have_link(organization.name, href: organization_path(organization))
     end
 
     include_examples 'a successful inventory creation', 'organization'

--- a/spec/features/inventories/show_inventory_spec.rb
+++ b/spec/features/inventories/show_inventory_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'features/feature_helpers'
+include FeatureHelpers
+
+RSpec.feature 'Showing an inventory' do
+  let(:member) { FactoryGirl.create(:user, :confirmed) }
+  let(:user) { FactoryGirl.create(:user, :confirmed) }
+  let(:inventory) { FactoryGirl.create(:inventory, users: [member]) }
+
+  shared_examples 'has inventory information' do
+    scenario 'shows the name and description of the inventory' do
+      expect(page).to have_content(inventory.name)
+      expect(page).to have_content(inventory.description)
+    end
+  end
+
+  feature 'as a member of the inventory' do
+    before do
+      login_as(member)
+    end
+
+    feature 'belonging to an organization' do
+      let(:organization) { FactoryGirl.create(:organization) }
+      let(:inventory) { FactoryGirl.create(:inventory, owner: organization, users: [member]) }
+
+      before do
+        visit organization_inventory_path(organization, inventory)
+      end
+
+      include_examples 'has inventory information'
+
+      scenario 'has a link to the organization' do
+        expect(page).to have_content(organization.name)
+      end
+    end
+
+    feature 'belonging to a user' do
+      before do
+        inventory.owner = member
+        visit user_inventory_path(member, inventory)
+      end
+
+      include_examples 'has inventory information'
+    end
+  end
+
+  feature 'as a user not part of the inventory' do
+    before do
+      login_as(user)
+      visit user_inventory_path(member, inventory)
+    end
+
+    scenario 'redirects to the root path' do
+      expect(current_path).to eq(root_path)
+    end
+
+    scenario 'shows a message saying why the user was redirected' do
+      expect(page).to have_content('You need to be part of this inventory to view it')
+    end
+  end
+
+  feature 'as a guest' do
+    before do
+      visit user_inventory_path(user, inventory)
+    end
+
+    will_redirect_to_login_page
+  end
+end

--- a/spec/features/organizations/show_organization_spec.rb
+++ b/spec/features/organizations/show_organization_spec.rb
@@ -6,6 +6,17 @@ RSpec.feature 'Showing an organization' do
   let(:owner) { FactoryGirl.create(:user, :confirmed) }
   let(:member) { FactoryGirl.create(:user, :confirmed) }
   let(:organization) { FactoryGirl.create(:organization, owner: owner, users: [owner, member]) }
+  let!(:inventory) { FactoryGirl.create(:inventory, owner: organization) }
+
+  shared_examples 'has organization information' do
+    scenario 'shows the name of the organization' do
+      expect(page).to have_content(organization.name)
+    end
+
+    scenario 'shows inventories the organization owns' do
+      expect(page).to have_link(inventory.name, href: organization_inventory_path(organization, inventory))
+    end
+  end
 
   feature 'as a member of the organization' do
     before do
@@ -13,9 +24,7 @@ RSpec.feature 'Showing an organization' do
       visit organization_path(organization)
     end
 
-    scenario 'shows the name of the organization' do
-      expect(page).to have_content(organization.name)
-    end
+    include_examples 'has organization information'
 
     scenario "doesn't show a link to create a new inventory" do
       expect(page).not_to have_link('Create an Inventory')
@@ -27,6 +36,8 @@ RSpec.feature 'Showing an organization' do
       login_as(owner)
       visit organization_path(organization)
     end
+
+    include_examples 'has organization information'
 
     scenario 'shows a link to create a new inventory' do
       expect(page).to have_link('Create an Inventory')

--- a/spec/features/organizations/show_organization_spec.rb
+++ b/spec/features/organizations/show_organization_spec.rb
@@ -3,8 +3,9 @@ require 'features/feature_helpers'
 include FeatureHelpers
 
 RSpec.feature 'Showing an organization' do
+  let(:owner) { FactoryGirl.create(:user, :confirmed) }
   let(:member) { FactoryGirl.create(:user, :confirmed) }
-  let(:organization) { FactoryGirl.create(:organization, users: [member]) }
+  let(:organization) { FactoryGirl.create(:organization, owner: owner, users: [owner, member]) }
 
   feature 'as a member of the organization' do
     before do
@@ -14,6 +15,21 @@ RSpec.feature 'Showing an organization' do
 
     scenario 'shows the name of the organization' do
       expect(page).to have_content(organization.name)
+    end
+
+    scenario "doesn't show a link to create a new inventory" do
+      expect(page).not_to have_link('Create an Inventory')
+    end
+  end
+
+  feature 'as the owner of the organization' do
+    before do
+      login_as(owner)
+      visit organization_path(organization)
+    end
+
+    scenario 'shows a link to create a new inventory' do
+      expect(page).to have_link('Create an Inventory')
     end
   end
 

--- a/spec/features/pages/visit_dashboard_spec.rb
+++ b/spec/features/pages/visit_dashboard_spec.rb
@@ -3,13 +3,29 @@ require 'features/feature_helpers'
 include FeatureHelpers
 
 RSpec.feature 'Visiting dashboard route' do
-  scenario 'as a logged in user shows organizations the user belongs to' do
-    user = FactoryGirl.create(:user, :confirmed)
-    orgs = FactoryGirl.create_list(:organization, 2, users: [user])
-    login_as(user)
-    visit dashboard_path
-    orgs.each do |org|
-      expect(page).to have_link(org.name, href: organization_path(org))
+  let(:user) { FactoryGirl.create(:user, :confirmed) }
+  let(:organization) { FactoryGirl.create(:organization, users: [user]) }
+  let!(:organization_inventory) { FactoryGirl.create(:inventory, owner: organization, users: [user]) }
+  let!(:user_inventory) { FactoryGirl.create(:inventory, owner: user, users: [user]) }
+
+  feature 'as a logged in user' do
+    before do
+      login_as(user)
+      visit dashboard_path
+    end
+
+    scenario 'shows organizations the user belongs to' do
+      expect(page).to have_content(organization.name)
+      expect(page).to have_link(organization.name, href: organization_path(organization))
+    end
+
+    scenario 'shows inventories the user belongs to in an organization' do
+      expect(page).to have_link("#{organization.name} / #{organization_inventory.name}",
+                                href: organization_inventory_path(organization, organization_inventory))
+    end
+
+    scenario 'shows inventories the user belongs to the user owns' do
+      expect(page).to have_link(user_inventory.name, href: user_inventory_path(user, user_inventory))
     end
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Users signing in' do
     before do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
-      click_button 'Log in'
+      click_button 'Sign in'
     end
 
     scenario 'succeeds and restricts access to the sign in route' do
@@ -41,7 +41,7 @@ RSpec.feature 'Users signing in' do
     before do
       fill_in 'Email', with: 'wrong_email@example.com'
       fill_in 'Password', with: 'wrong_password'
-      click_button 'Log in'
+      click_button 'Sign in'
     end
 
     include_examples 'a failed sign in attempt'
@@ -49,7 +49,7 @@ RSpec.feature 'Users signing in' do
 
   feature 'with no credentials' do
     before do
-      click_button 'Log in'
+      click_button 'Sign in'
     end
 
     include_examples 'a failed sign in attempt'

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe Inventory, type: :model do
       expect(inventory.users).to eq users
     end
   end
+
+  describe '#owner' do
+    it 'is invalid when nil' do
+      expect(FactoryGirl.build(:inventory, owner: nil)).not_to be_valid
+    end
+
+    it 'can be a user' do
+      user = FactoryGirl.create(:user)
+      inventory = FactoryGirl.create(:inventory, owner: user)
+      expect(inventory.owner_type).to eq('User')
+    end
+
+    it 'can be an organization' do
+      organization = FactoryGirl.create(:organization)
+      inventory = FactoryGirl.create(:inventory, owner: organization)
+      expect(inventory.owner_type).to eq('Organization')
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do
+  let(:organization) { FactoryGirl.create(:organization) }
+
   it 'has a valid factory' do
-    expect(FactoryGirl.build(:organization)).to be_valid
+    expect(organization).to be_valid
   end
 
   describe '#name' do
@@ -39,16 +41,21 @@ RSpec.describe Organization, type: :model do
     end
 
     it 'is a user' do
-      organization = FactoryGirl.create(:organization)
       expect(organization.owner).to be_a(User)
     end
   end
 
   describe '#users' do
     it 'returns users belonging to the organization' do
-      organization = FactoryGirl.create(:organization)
       users = FactoryGirl.create_list(:user, 2, organizations: [organization])
       expect(organization.users).to eq(users)
+    end
+  end
+
+  describe '#owned_inventories' do
+    it 'returns inventories it owns' do
+      inventories = FactoryGirl.create_list(:inventory, 2, owner: organization)
+      expect(organization.owned_inventories.sort).to eq(inventories.sort)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let(:user) { FactoryGirl.create(:user) }
+
   it 'has a valid factory' do
-    expect(FactoryGirl.build(:user)).to be_valid
+    expect(user).to be_valid
   end
 
   describe '#confirmed' do
@@ -17,7 +19,6 @@ RSpec.describe User, type: :model do
 
   describe '#inventories' do
     it 'returns inventories it belongs to' do
-      user = FactoryGirl.create(:user)
       inventories = FactoryGirl.create_list(:inventory, 2, users: [user])
       expect(user.inventories).to eq(inventories)
     end
@@ -25,7 +26,6 @@ RSpec.describe User, type: :model do
 
   describe '#organizations' do
     it 'returns organizations it belongs to' do
-      user = FactoryGirl.create(:user)
       orgs = FactoryGirl.create_list(:organization, 2, users: [user])
       expect(user.organizations).to eq(orgs)
     end
@@ -33,9 +33,15 @@ RSpec.describe User, type: :model do
 
   describe '#owned_organizations' do
     it 'returns organizations it owns' do
-      user = FactoryGirl.create(:user)
       orgs = FactoryGirl.create_list(:organization, 2, owner: user)
       expect(user.owned_organizations).to eq(orgs)
+    end
+  end
+
+  describe '#owned_inventories' do
+    it 'returns inventories it owns' do
+      inventories = FactoryGirl.create_list(:inventory, 2, owner: user)
+      expect(user.owned_inventories).to match_array(inventories.sort)
     end
   end
 end


### PR DESCRIPTION
resolves #79, #57, #33 

Create polymorphic association between inventories and an owner which can be a user or an organization

inventory actions are nested inside of organization and user routes.  Might want to create a user show view or profile so that users/user_id is a valid route in the future.

Lots of improvement to be done on dashboard, inventory etc but this pull request was getting large enough as is and can be done in a future commit.

I removed the min 6 characters helpers on password since it didn't stay formatted correctly on error and it is inconsistent with other forms (we don't have required next to fields saying they are required, we don't have a statement next to description saying it can't be more than 255 characters, etc.  We should talk later about client side validations/helpers)

## Basic Dashboard Page
![image](https://user-images.githubusercontent.com/5897420/28742190-a447dbae-73e6-11e7-82b4-2c8d71470f59.png)

## Basic Organization Page
![image](https://user-images.githubusercontent.com/5897420/28742193-bab7f752-73e6-11e7-97d3-90d83860cd0b.png)

## Form to create an inventory for an organization
![image](https://user-images.githubusercontent.com/5897420/28742200-d0973db2-73e6-11e7-97e4-46b30d4d4fb2.png)

## Form to create an inventory for yourself
![image](https://user-images.githubusercontent.com/5897420/28742204-ef79e680-73e6-11e7-8b18-2a529e1c6c16.png)
Might have a link to username or profile link if we implement that in the future.  Not much point in saying creating inventory for user@example.com at the moment

## Sign up form showing error colors on input fields.
![image](https://user-images.githubusercontent.com/5897420/28742362-a8a4a0a2-73ea-11e7-9aac-29bfa1578b1c.png)
