### PR TITLE
Refactor orgs show to remove the code smell of 2 instance variables

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -19,7 +19,6 @@ class OrganizationsController < ApplicationController
 
   def show
     @organization = Organization.find(params[:id])
-    @inventories = @organization.owned_inventories
     return if @organization.users.include? current_user
     flash[:alert] = 'You need to be part of this organization to view it'
     redirect_to root_path

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -3,9 +3,9 @@
 <div class='card'>
   <h4>Inventories</h4>
 
-  <% unless @inventories.empty? %>
+  <% unless @organization.owned_inventories.empty? %>
     <ul>
-      <% @inventories.each do |inventory| %>
+      <% @organization.owned_inventories.each do |inventory| %>
         <li>
           <%= link_to inventory.name, organization_inventory_path(inventory.owner, inventory) %>
         </li>

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -21,11 +21,6 @@ RSpec.describe OrganizationsController do
         subject.show
         expect(subject.view_assigns['organization']).to eq organization
       end
-
-      it 'assigns @inventories' do
-        subject.show
-        expect(subject.view_assigns['inventories']).to match_array(inventories)
-      end
     end
 
     context 'when user is not a part of the organization' do

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'organizations/show', type: :view do
     end
 
     it "displays links to the organization's inventories" do
-      inventories.each do |inventory|
+      organization.owned_inventories.each do |inventory|
         expect(rendered).to have_link(inventory.name)
       end
     end

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 RSpec.describe 'organizations/show', type: :view do
   let(:owner) { FactoryGirl.build_stubbed(:user) }
   let(:member) { FactoryGirl.build_stubbed(:user) }
-  let(:organization) { FactoryGirl.build_stubbed(:organization, owner: owner, users: [owner, member]) }
-  let(:inventories) { FactoryGirl.build_stubbed_list(:inventory, 2, owner: organization) }
+  let(:inventories) { FactoryGirl.build_stubbed_list(:inventory, 2) }
+  let(:organization) { FactoryGirl.build_stubbed(:organization, owner: owner, users: [owner, member], owned_inventories: inventories) }
 
   before do
     assign(:organization, organization)
-    assign(:inventories, inventories)
     allow(view).to receive(:current_user).and_return(member)
     render
   end


### PR DESCRIPTION
This smell was made apparent while writing view specs when the
test reading as 'displays links to the organization's inventories
didn't read true to the actual assertion
Resolves #117