### PR TITLE
Fix username migration under certain circumstances

### DIFF
--- a/db/migrate/20170731170604_add_username_to_users.rb
+++ b/db/migrate/20170731170604_add_username_to_users.rb
@@ -1,5 +1,16 @@
 class AddUsernameToUsers < ActiveRecord::Migration[5.1]
-  def change
-    add_column :users, :username, :string, limit: 255, null: false
+  def up
+    add_column :users, :username, :string, limit: 255
+
+    User.all.each do |user|
+      user.username = user.email
+      user.save!
+    end
+
+    change_column :users, :username, :string, limit: 255, null: false
+  end
+
+  def down
+    remove_column :users, :username
   end
 end


### PR DESCRIPTION
Heroku's deploy was failing due to username not having a default value
as well as username having a null constraint. Upon adding this column,
the database didn't know what value the username field should inherit so
the migration failed. This wasn't an issue in dev envs because on this
migration run, I assume that there were no users at first.