### PR TITLE
Update User factory to use 25 char max usernames

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user do
     email { Faker::Internet.email }
     password { Faker::Internet.password }
-    sequence(:username) { |n| "#{Faker::Internet.user_name}#{n}" }
+    sequence(:username) { |n| "#{Faker::Internet.user_name(8..25)}#{n}" }
 
     trait :confirmed do
       confirmed_at Time.now


### PR DESCRIPTION
Travis gave me this: 
![image](https://user-images.githubusercontent.com/5464881/33161271-48bdd796-cff0-11e7-9dca-0c9186b065b5.png)
So we could limit the length of the generated usernames!